### PR TITLE
ci: add build verification workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install --frozen-lockfile
+
+      - run: bun run build


### PR DESCRIPTION
## Why

Ensure the project builds successfully on every push and pull request.

## What

- Add `.github/workflows/ci.yml` that runs `bun run build` on push to `main` and on pull requests