### PR TITLE
ci: add check-changeset workflow

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Check for changeset file
         run: |
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-          CHANGESET_FILES=$(echo "$CHANGED_FILES" | grep -E '^\.changeset/[^/]+\.md$' | grep -v 'README.md' || true)
+          CHANGESET_FILES=$(echo "$CHANGED_FILES" | grep -E '^\.changeset/[^/]+\.md$' | grep -v '^\.changeset/README\.md$' || true)
 
           if [ -z "$CHANGESET_FILES" ]; then
             echo "Error: No changeset file found. Please run 'bun changeset' and commit the generated file."


### PR DESCRIPTION
## Why

To detect missing changeset files in CI when a PR title starts with `feat:` or `fix:`.

## What

- Add `.github/workflows/check-changeset.yml`
- Run the job only when the PR title starts with `feat:` or `fix:`
- Fail with `exit 1` if no `.changeset/*.md` file (excluding `README.md`) is found in the diff