### PR TITLE
docs: document --resolved and --unresolved flags for list subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ gh review-comment list [<pr>] [flags]
 | :------------- | :------------------------------------------------------ |
 | `-R`, `--repo` | Select another repository using the `OWNER/REPO` format |
 | `--json`       | Output raw JSON                                         |
+| `--resolved`   | Show only resolved threads                              |
+| `--unresolved` | Show only unresolved threads                            |
 
 ### `reply`
 


### PR DESCRIPTION
## Why

PR #21 added `--resolved` and `--unresolved` flags to the `list` subcommand, but the README was not updated to reflect these new flags.

## What

- Add `--resolved` and `--unresolved` flags to the flags table of the `list` subcommand