### PR TITLE
ci: add check PR title workflow

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,7 +1,7 @@
 name: Check PR Title
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened]
 
 jobs:


### PR DESCRIPTION
## Why

To automatically validate in CI that PR titles follow the Conventional Commits format. Since `check-changeset.yml` already assumes titles starting with `feat:` or `fix:`, a mechanism to enforce the title format was needed.

## What

- Add `.github/workflows/check-pr-title.yml`
- Use `amannn/action-semantic-pull-request@v6` to validate PR titles
- Trigger: `pull_request_target` on `opened`, `edited`, `reopened`