### PR TITLE
fix: remove --repo flag from pr auto-detection in list subcommand

### DIFF
--- a/.changeset/fix-pr-auto-detection.md
+++ b/.changeset/fix-pr-auto-detection.md
@@ -1,0 +1,5 @@
+---
+"gh-review-comment": patch
+---
+
+Fix PR auto-detection in `list` subcommand failing with "argument required when using the --repo flag".

--- a/index.ts
+++ b/index.ts
@@ -351,15 +351,7 @@ const listCommand = define({
 
     let prNumber = pr;
     if (!prNumber) {
-      const prResult = Bun.spawnSync([
-        "gh",
-        "pr",
-        "view",
-        "--json",
-        "number",
-        "-q",
-        ".number",
-      ]);
+      const prResult = Bun.spawnSync(["gh", "pr", "view", "--json", "number", "-q", ".number"]);
       if (prResult.exitCode !== 0) {
         console.error(new TextDecoder().decode(prResult.stderr).trim());
         process.exit(1);


### PR DESCRIPTION
## Why

`gh pr view --repo <repo>` does not support PR auto-detection — it requires an explicit PR number or URL when `--repo` is specified. This caused `list` (and `list --unresolved` etc.) to fail with \"argument required when using the --repo flag\" when no PR number was given.

## What

- Remove `--repo` from the `gh pr view` call used for PR auto-detection in `list`
- `gh pr view` without `--repo` correctly auto-detects the PR from the current branch