### PR TITLE
docs: add AGENTS.md and Claude Code project settings

### DIFF
--- a/.agents/skills/use-gunshi-cli/SKILL.md
+++ b/.agents/skills/use-gunshi-cli/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: use-gunshi-cli
+description: Use the Gunshi library to create command-line interfaces in JavaScript/TypeScript.
+globs: "*.ts, *.tsx, *.js, *.jsx, package.json"
+alwaysApply: false
+---
+
+use gunshi library for creating cli instead of other libraries including cac, yargs, commander, etc.
+Gunshi is a modern javascript command-line library
+
+For more information, read the gunshi API docs in `node_modules/@gunshi/docs/**.md`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bun run dev)",
+      "Bash(bun run build)",
+      "Bash(bun run fmt)",
+      "Bash(bun run fmt:check)"
+    ]
+  }
+}

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+## Overview
+
+`gh-review-comment` is a GitHub CLI extension for managing pull request review comments.
+
+### Commands
+
+| Command                                         | Description                 |
+| :---------------------------------------------- | :-------------------------- |
+| `gh review-comment list`                        | List review threads on a PR |
+| `gh review-comment reply <commentId> -b <body>` | Reply to a review comment   |
+| `gh review-comment resolve <threadId>`          | Resolve a review thread     |
+| `gh review-comment unresolve <threadId>`        | Unresolve a review thread   |
+
+## Tech Stack
+
+- Runtime / Package manager: **Bun**
+- CLI framework: **Gunshi**
+- Language: **TypeScript**
+- Formatter: **oxfmt**
+
+## Project Structure
+
+- `index.ts` — single entrypoint containing all commands
+- `package.json` — version is imported in `index.ts` via `import pkg from './package.json'`
+
+## Development
+
+```bash
+bun install        # install dependencies
+bun run dev        # run locally
+bun run build      # compile to dist/gh-review-comment
+bun run fmt        # format code
+bun run fmt:check  # check formatting
+```
+
+## CLI Development
+
+When creating or modifying CLI commands, use the `use-gunshi-cli` skill.
+
+## Git / GitHub
+
+- Branch strategy: always create a feature branch; never commit directly to `main`
+- Commit style: Conventional Commits (English)
+- Merge strategy: Squash only
+
+### Before Committing
+
+Verify the following commands succeed:
+
+```bash
+bun run build
+bun run fmt:check
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       },
       "devDependencies": {
         "@changesets/cli": "2.29.8",
+        "@gunshi/docs": "0.29.2",
         "@tsconfig/bun": "1.0.10",
         "@types/bun": "1.3.9",
         "oxfmt": "0.35.0",
@@ -17,6 +18,8 @@
     },
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.0.14", "", { "dependencies": { "@changesets/config": "^3.1.2", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA=="],
@@ -52,6 +55,8 @@
     "@changesets/types": ["@changesets/types@6.1.0", "", {}, "sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA=="],
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
+
+    "@gunshi/docs": ["@gunshi/docs@0.29.2", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "tinyexec": "^1.0.2" }, "bin": { "gunshi-docs-init": "bin/init.js" } }, "sha512-XWJClT3zQ288dtC9hZNyRt9faaT5zcAygBu1Q5W+sefZMFOTRUQJxaHPEuE7vS62GaiavGibdukl8RoF3zeT5A=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -253,6 +258,8 @@
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
+    "tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
@@ -264,6 +271,8 @@
     "universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "@antfu/install-pkg/package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "2.29.8",
+    "@gunshi/docs": "0.29.2",
     "@tsconfig/bun": "1.0.10",
     "@types/bun": "1.3.9",
     "oxfmt": "0.35.0",


### PR DESCRIPTION
## Why

Provide context for Claude Code and other AI agents working on this repository.

## What

- Add `AGENTS.md` with project overview, tech stack, dev commands, Git conventions, and pre-commit checklist
- Update `CLAUDE.md` to reference `@AGENTS.md`
- Move skills to `.agents/skills/` and symlink `.claude/skills` to it
- Add `.claude/settings.json` with permission allows for `bun run` commands