### PR TITLE
fix: pass reply body via JSON stdin to support backticks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -181,15 +181,18 @@ const replyCommand = define({
     const pullRequestUrl = new TextDecoder().decode(commentResult.stdout).trim();
     const prNumber = pullRequestUrl.split("/").pop();
 
-    const result = Bun.spawnSync([
-      "gh",
-      "api",
-      "-X",
-      "POST",
-      `/repos/${owner}/${repoName}/pulls/${prNumber}/comments/${commentId}/replies`,
-      "-f",
-      `body=${body}`,
-    ]);
+    const result = Bun.spawnSync(
+      [
+        "gh",
+        "api",
+        "-X",
+        "POST",
+        `/repos/${owner}/${repoName}/pulls/${prNumber}/comments/${commentId}/replies`,
+        "--input",
+        "-",
+      ],
+      { stdin: JSON.stringify({ body }) },
+    );
 
     if (result.exitCode !== 0) {
       console.error(new TextDecoder().decode(result.stderr).trim());


### PR DESCRIPTION
## Why

Using `-f body=...` with `gh api` caused issues when the body contained backticks or other special characters that could be misinterpreted.

## What

Switch to `--input -` with `JSON.stringify({ body })` passed via stdin, which safely handles all special characters in the reply body.